### PR TITLE
CRAW-860 feat: add influxdb_database routing

### DIFF
--- a/telegraf.go
+++ b/telegraf.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 )
 
-var databaseRoutingTag = "influxdb_database"
-
 func createDialConn(addr string) (net.Conn, error) {
 	URL, err := url.Parse(addr)
 	if err != nil {

--- a/telegraf.go
+++ b/telegraf.go
@@ -43,11 +43,11 @@ type ClientImpl struct {
 // > client := NewClientImpl("tcp://127.0.0.1:8094")
 func NewClientImpl(addr string) (*ClientImpl, error) {
 	conn, err := createDialConn(addr)
-	defaultTags := new(map[string]interface{})
+	defaultTags := make(map[string]interface{})
 
 	return &ClientImpl{
 		conn,
-		*defaultTags,
+		defaultTags,
 	}, err
 }
 


### PR DESCRIPTION
The following adds an `influxdb_database` routing key to our messages. A similar implementation can be found in ps-go's [TelegrafClient](https://github.com/PriceSpider-NeuIntel/ps-go/blob/71617cbef841ba3633e558e6e40d801d7d205f6f/dotnet/PriceSpider.Metrics/Client/TelegrafClient.cs#L38-L46) as well as in the [node-metrics-client](https://github.com/PriceSpider-NeuIntel/node-metrics-client/blob/c1b929747b5010fc3744f9ba60d5370892914d31/src/client.js#L27-L34)

This is related to a [PR for crawler6](https://github.com/PriceSpider-NeuIntel/ps-go/pull/1068) which adds metrics using telegraf.

This PR will effect both [bullet](https://github.com/PriceSpider-NeuIntel/bullet/blob/a15e11983815a4cf14ef8a9bd2e08d6a2ab3e6b6/bullet.go#L56) and [rosetta](https://github.com/PriceSpider-NeuIntel/rosetta/blob/f6cba581651882f70008bccdfffcfcf64d2dba82/main.go#L54)

[CRAW-860](https://pricespider.atlassian.net/browse/CRAW-860)