### PR TITLE
Fix allowing an empty tag set to be passed

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -16,10 +16,10 @@ type Metric struct {
 // toLP translates the initiated metric struct to the outgoing
 // influxDB line protocol format
 func (t *Metric) toLP(withTimestamp bool) string {
-	tags := formatAttr(t.Tags, false)
+	tags := formatTags(t.Tags)
 	fields := formatAttr(t.Fields, true)
 
-	base := fmt.Sprintf("%s,%s %s", t.Measurement, tags, fields)
+	base := fmt.Sprintf("%s%s %s", t.Measurement, tags, fields)
 
 	if withTimestamp {
 		utc, _ := time.LoadLocation("UTC")
@@ -29,6 +29,14 @@ func (t *Metric) toLP(withTimestamp bool) string {
 	}
 
 	return base
+}
+
+func formatTags(tags map[string]interface{}) string {
+	if tags == nil {
+		return ""
+	}
+
+	return fmt.Sprintf(",%s", formatAttr(tags, false))
 }
 
 func escapeString(s string) string {

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -30,6 +30,20 @@ func TestToLP(t *testing.T) {
 	// }
 }
 
+func TestEmptyTags(t *testing.T) {
+	testMetric := &Metric{
+		Measurement: "testM",
+		Tags:        nil,
+		Fields:      map[string]interface{}{"field1": 2},
+	}
+	clpString := testMetric.toLP(false)
+	expected := "testM field1=2i"
+	if clpString != expected {
+		emsg := fmt.Sprintf("Did not format point properly - got: %s, expected: %s", clpString, expected)
+		t.Errorf(emsg)
+	}
+}
+
 func TestGetFieldString(t *testing.T) {
 	v := "fooString"
 	fs := getFieldString(v)

--- a/telegraf.go
+++ b/telegraf.go
@@ -8,6 +8,16 @@ import (
 	"strings"
 )
 
+// InvalidUsageError used to describe when an API is used
+// incorrectly or in a way that would clash with CLP
+type InvalidUsageError struct {
+	s string
+}
+
+func (e *InvalidUsageError) Error() string {
+	return e.s
+}
+
 func createDialConn(addr string) (net.Conn, error) {
 	URL, err := url.Parse(addr)
 	if err != nil {
@@ -52,6 +62,10 @@ func (t *ClientImpl) Close() {
 // WritePoint will write a single metric. For multiple metrics at once,
 // use WritePoints.
 func (t *ClientImpl) WritePoint(p *Metric) error {
+	if p.Fields == nil {
+		return &InvalidUsageError{"metrics must include at least 1 field"}
+	}
+
 	_, err := fmt.Fprintln(t.conn, p.toLP(true))
 	return err
 }

--- a/telegraf.go
+++ b/telegraf.go
@@ -74,6 +74,9 @@ func (t *ClientImpl) WritePoint(p *Metric) error {
 func (t *ClientImpl) WritePoints(p []*Metric) error {
 	var pointArr []string
 	for _, m := range p {
+		if m.Fields == nil {
+			return &InvalidUsageError{"metrics must include at least 1 field"}
+		}
 		pointArr = append(pointArr, m.toLP(true))
 	}
 	_, err := fmt.Fprintln(t.conn, strings.Join(pointArr, "\n"))


### PR DESCRIPTION
Previously the LP protocol method didnt format points that didnt include a tag set. This fixes that bug, and adds some additional error cases.